### PR TITLE
Remove unicode function that raised NameError

### DIFF
--- a/msp.py
+++ b/msp.py
@@ -25,9 +25,7 @@ class MSP:
          Convert a Boolean formula represented as a string into a policy represented like a tree.
         """
 
-        assert type(policy_string) in [str, unicode], "invalid type for policy_string"
-        if(type(policy_string) == str):
-            policy_string = unicode(policy_string)
+        assert type(policy_string) is str, "invalid type for policy_string"
         parser = PolicyParser()
         policy_obj = parser.parse(policy_string)
         _dictCount, _dictLabel = {}, {}


### PR DESCRIPTION
Since Python 3, `unicode` function is merged with `str`